### PR TITLE
Update supported Ruby versions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [ 3, 3.3, 3.2 ]
+        ruby-version: [ "4.0", 3.4, 3.3 ]
 
     name: Ruby ${{ matrix.ruby-version }}
 

--- a/rspec-protobuf.gemspec
+++ b/rspec-protobuf.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.files       = `git ls-files * ':!:spec'`.split("\n")
 
-  s.required_ruby_version = ">= 3.2"
+  s.required_ruby_version = ">= 3.3"
 
   s.add_dependency "google-protobuf", ">= 3"
   s.add_dependency "rspec-expectations", ">= 3"


### PR DESCRIPTION
## Summary
- Drop EOL Ruby 3.2 support by raising `required_ruby_version` to `>= 3.3`
- Update CI to test Ruby 3.3, 3.4, and 4.0

## Validation
- `/opt/homebrew/opt/ruby@3.3/bin/bundle exec rspec` - 101 examples, 0 failures
- `/opt/homebrew/opt/ruby@3.4/bin/bundle exec rspec` - 101 examples, 0 failures
- `/opt/homebrew/opt/ruby@4.0/bin/bundle exec rspec` - 101 examples, 0 failures
- `git diff --check`