### PR TITLE
Use static, dependabot-parseable forms in gemspec

### DIFF
--- a/rspec-protobuf.gemspec
+++ b/rspec-protobuf.gemspec
@@ -1,16 +1,12 @@
-package_name = File.basename(__FILE__).split(".")[0]
-load Dir.glob("lib/**/version.rb")[0]
-
-package = RSpec::Protobuf
-
+require_relative "lib/rspec/protobuf/version"
 
 Gem::Specification.new do |s|
-  s.name        = package_name
-  s.version     = package.const_get "VERSION"
+  s.name        = "rspec-protobuf"
+  s.version     = RSpec::Protobuf::VERSION
   s.authors     = ["Daniel Pepper"]
-  s.summary     = package.to_s
+  s.summary     = "RSpec::Protobuf"
   s.description = "RSpec matchers for Protobuf"
-  s.homepage    = "https://github.com/dpep/#{package_name}"
+  s.homepage    = "https://github.com/dpep/rspec-protobuf"
   s.license     = "MIT"
   s.files       = `git ls-files * ':!:spec'`.split("\n")
 


### PR DESCRIPTION
## Summary

Dependabot's gemspec parser is **static** — it doesn't eval Ruby, it reads the AST and only handles literal `s.name = "string"` and `s.version = SomeConst::VERSION`. The dynamic forms we had defeated that.

When dependabot can't extract the version statically it falls back to `0.0.1` and writes that into `Gemfile.lock`, which then fails CI in frozen mode (gem version mismatch). See dpep/meddleware_rb#18 for the original diagnosis.

This PR switches to the canonical Bundler-scaffold shape:

```ruby
s.name    = "rspec-protobuf"
s.version = RSpec::Protobuf::VERSION
```


## Test plan

- [x] `Bundler.load_gemspec("rspec-protobuf.gemspec")` parses statically to name=`rspec-protobuf`, version=`0.4.0`
- [x] `bundle install` runs cleanly

## Pattern reference

- dpep/meddleware_rb#18 (diagnosis)
- dpep/amenable_rb#7 (template)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
