### PR TITLE
Use double quotes in spec_helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require "debug"
 require "rspec"
-require 'rspec/matchers/fail_matchers'
+require "rspec/matchers/fail_matchers"
 require "simplecov"
 
 SimpleCov.start do


### PR DESCRIPTION
Lone single-quoted require in `spec_helper.rb` — switch to double quotes for consistency with the rest of the file.

🤖 vibed with Claude Code