### PR TITLE
Add custom negation failure message

### DIFF
--- a/lib/rspec/protobuf.rb
+++ b/lib/rspec/protobuf.rb
@@ -48,6 +48,12 @@ RSpec::Matchers.define :be_a_protobuf do |type = nil, **attrs|
 
   failure_message { @fail_msg }
 
+  failure_message_when_negated do |actual|
+    msg = "expected #{actual} not to be #{description}"
+    msg += " with #{attrs}" unless attrs.empty?
+    msg
+  end
+
   diffable
 end
 

--- a/spec/matcher_spec.rb
+++ b/spec/matcher_spec.rb
@@ -52,8 +52,9 @@ describe :be_a_protobuf do
       expect {
         is_expected.not_to be_a_protobuf(msg: "Hello")
       }.to fail_including(
+        "not to be a Protobuf with ",
         # Ruby 3.4+ renders symbol-keyed hashes as {key: value}; simplify once Ruby 3.3 support is dropped.
-        Regexp.union('not to be a Protobuf with {:msg=>"Hello"}', 'not to be a Protobuf with {msg: "Hello"}'),
+        Regexp.union('{:msg=>"Hello"}', '{msg: "Hello"}'),
       )
     end
   end

--- a/spec/matcher_spec.rb
+++ b/spec/matcher_spec.rb
@@ -47,6 +47,15 @@ describe :be_a_protobuf do
         '+:msg => "Hello",'
       )
     end
+
+    it "produces a negation message naming the matched attributes" do
+      expect {
+        is_expected.not_to be_a_protobuf(msg: "Hello")
+      }.to fail_including(
+        # Ruby 3.4+ renders symbol-keyed hashes as {key: value}; simplify once Ruby 3.3 support is dropped.
+        Regexp.union('not to be a Protobuf with {:msg=>"Hello"}', 'not to be a Protobuf with {msg: "Hello"}'),
+      )
+    end
   end
 
   context "when input is erroneous" do


### PR DESCRIPTION
A failing `not_to be_a_protobuf(...)` previously fell back to RSpec's generic message and never echoed the attributes being negated against. This adds a `failure_message_when_negated` that names the matched attributes, consistent with the gem's improved error output.

| Expectation | Message |
|---|---|
| `not_to be_a_protobuf` | `expected <…> not to be a Protobuf` |
| `not_to be_a_protobuf(MyMessage)` | `expected <…> not to be a MyMessage Protobuf` |
| `not_to be_a_protobuf(msg: "Hello")` | `expected <…> not to be a Protobuf with {msg: "Hello"}` |

🤖 vibed with Claude Code